### PR TITLE
[Comp V3] Parse info only about tokens that are supported in marketAssets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@defisaver/positions-sdk",
-  "version": "0.0.121",
+  "version": "0.0.123",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@defisaver/positions-sdk",
-      "version": "0.0.121",
+      "version": "0.0.123",
       "license": "ISC",
       "dependencies": {
-        "@defisaver/tokens": "^1.5.30",
+        "@defisaver/tokens": "^1.5.31",
         "@ethersproject/bignumber": "^5.7.0",
         "@morpho-org/morpho-aave-v3-sdk": "^1.5.3",
         "decimal.js": "^10.4.3"
@@ -2432,9 +2432,9 @@
       }
     },
     "node_modules/@defisaver/tokens": {
-      "version": "1.5.30",
-      "resolved": "https://registry.npmjs.org/@defisaver/tokens/-/tokens-1.5.30.tgz",
-      "integrity": "sha512-qywSIKXSwJkDxmpd4F6lkZjLce4QNC6uqj4ZcqUzE94FozVZz0rrVJmtGHQwV1stWaCLOPls6JMvCEqRzvL6aA==",
+      "version": "1.5.31",
+      "resolved": "https://registry.npmjs.org/@defisaver/tokens/-/tokens-1.5.31.tgz",
+      "integrity": "sha512-R/vBlPmhDmD3cPi6FHoyLmhjzCgB5agGWcl/G1AG8R3OTQTF5MVX5bCEHAyuFEcL7i3LqFvhoZLVaSs8g3jsZw==",
       "dependencies": {
         "decimal.js": "^10.2.1"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@defisaver/positions-sdk",
-  "version": "0.0.122",
+  "version": "0.0.123",
   "description": "",
   "main": "./cjs/index.js",
   "module": "./esm/index.js",
@@ -20,7 +20,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@defisaver/tokens": "^1.5.30",
+    "@defisaver/tokens": "^1.5.31",
     "@ethersproject/bignumber": "^5.7.0",
     "@morpho-org/morpho-aave-v3-sdk": "^1.5.3",
     "decimal.js": "^10.4.3"

--- a/scripts/updateMarkets/index.js
+++ b/scripts/updateMarkets/index.js
@@ -15,6 +15,7 @@ const {
   cUSDCv3,
   cETHv3,
   MorphoAaveV3ProxyEthMarket,
+  cUSDTv3,
 } = require('../../src/config/contracts');
 
 const getWeb3 = (chainId) => new Web3(({
@@ -117,14 +118,22 @@ const compound = {
       1: {
         [cETHv3.networks[1].address.toLowerCase()]: 'v3ETHCollAssetsEth',
         [cUSDCv3.networks[1].address.toLowerCase()]: 'v3USDCCollAssetsEth',
+        [cUSDTv3.networks[1].address.toLowerCase()]: 'v3USDTCollAssetsEth',
+      },
+      10: {
+        [cUSDCv3.networks[10].address.toLowerCase()]: 'v3USDCCollAssetsOpt',
+        [cUSDTv3.networks[10].address.toLowerCase()]: 'v3USDTCollAssetsOpt',
       },
       8453: {
         [cETHv3.networks[8453].address.toLowerCase()]: 'v3ETHCollAssetsBase',
         [cUSDbCv3.networks[8453].address.toLowerCase()]: 'v3USDbCCollAssetsBase',
+        [cUSDCv3.networks[8453].address.toLowerCase()]: 'v3USDCCollAssetsBase',
       },
       42161: {
         [cUSDCev3.networks[42161].address.toLowerCase()]: 'v3USDCeCollAssetsArb',
         [cUSDCv3.networks[42161].address.toLowerCase()]: 'v3USDCCollAssetsArb',
+        [cETHv3.networks[42161].address.toLowerCase()]: 'v3ETHCollAssetsArb',
+        [cUSDTv3.networks[42161].address.toLowerCase()]: 'v3USDTCollAssetsArb',
       },
     },
     networks: [1, 8453, 42161],

--- a/src/config/contracts.js
+++ b/src/config/contracts.js
@@ -353,6 +353,9 @@ module.exports = {
       "1": {
         "address": "0xa17581a9e3356d9a858b789d68b4d866e593ae94"
       },
+      "10": {
+        "address": "0xE36A30D249f7761327fd973001A32010b521b6Fd"
+      },
       "8453": {
         "address": "0x46e6b214b524310239732D51387075E0e70970bf"
       },

--- a/src/markets/compound/index.ts
+++ b/src/markets/compound/index.ts
@@ -117,7 +117,7 @@ export const COMPOUND_V3_USDCe = (networkId: NetworkNumber): CompoundMarketData 
 });
 
 export const COMPOUND_V3_ETH = (networkId: NetworkNumber): CompoundMarketData => ({
-  chainIds: [NetworkNumber.Eth, NetworkNumber.Base, NetworkNumber.Arb],
+  chainIds: [NetworkNumber.Eth, NetworkNumber.Base, NetworkNumber.Arb, NetworkNumber.Opt],
   label: 'Compound V3 - ETH',
   shortLabel: 'v3',
   value: CompoundVersions.CompoundV3ETH,

--- a/src/markets/compound/marketsAssets.ts
+++ b/src/markets/compound/marketsAssets.ts
@@ -8,8 +8,8 @@ export const compoundV2CollateralAssets = [
 
 export const v3USDCCollAssetsEth = ['COMP', 'WBTC', 'ETH', 'UNI', 'LINK', 'wstETH'];
 export const v3USDCCollAssetsArb = ['ARB', 'ETH', 'GMX', 'WBTC', 'wstETH'];
-export const v3USDCCollAssetsBase = ['ETH', 'cbETH'];
-export const v3USDCCollAssetsOpt = ['ETH', 'OP', 'WBTC'];
+export const v3USDCCollAssetsBase = ['ETH', 'cbETH', 'wstETH'];
+export const v3USDCCollAssetsOpt = ['ETH', 'OP', 'WBTC', 'wstETH'];
 
 // @dev Keep assets in array, do not assign directly, so we can parse it and edit it programmatically with `scripts/updateMarkets`
 export const v3USDCCollAssets = {
@@ -31,12 +31,13 @@ export const v3USDCeCollAssets = {
 
 export const v3ETHCollAssetsEth = ['cbETH', 'wstETH', 'rETH', 'rsETH', 'weETH', 'osETH', 'WBTC', 'ezETH'];
 export const v3ETHCollAssetsBase = ['cbETH', 'ezETH'];
-export const v3ETHCollAssetsArb = ['weETH', 'rETH', 'wstETH', 'WBTC'];
+export const v3ETHCollAssetsArb = ['weETH', 'rETH', 'wstETH', 'WBTC', 'rsETH'];
+export const v3ETHCollAssetsOpt = ['rETH', 'wstETH', 'WBTC'];
 
 // @dev Keep assets in array, do not assign directly, so we can parse it and edit it programmatically with `scripts/updateMarkets`
 export const v3ETHCollAssets = {
   [NetworkNumber.Eth]: v3ETHCollAssetsEth,
-  [NetworkNumber.Opt]: [],
+  [NetworkNumber.Opt]: v3ETHCollAssetsOpt,
   [NetworkNumber.Arb]: v3ETHCollAssetsArb,
   [NetworkNumber.Base]: v3ETHCollAssetsBase,
 } as const;
@@ -53,7 +54,7 @@ export const v3USDbCCollAssets = {
 
 export const v3USDTCollAssetsEth = ['ETH', 'WBTC', 'wstETH', 'COMP', 'UNI', 'LINK'];
 export const v3USDTCollAssetsArb = ['ETH', 'WBTC', 'wstETH', 'ARB', 'GMX'];
-export const v3USDTCollAssetsOpt = ['ETH', 'WBTC', 'OP'];
+export const v3USDTCollAssetsOpt = ['ETH', 'WBTC', 'OP', 'wstETH'];
 
 // @dev Keep assets in array, do not assign directly, so we can parse it and edit it programmatically with `scripts/updateMarkets`
 export const v3USDTCollAssets = {


### PR DESCRIPTION
- use only assets from internal assets list instead of onchain to be consistent with other protocols
- add Comp V3 ETH on Op
- Update assets