### PR TITLE
adding information about the kind of reward the user is getting

### DIFF
--- a/src/aaveV3/index.ts
+++ b/src/aaveV3/index.ts
@@ -290,6 +290,7 @@ export async function getAaveV3MarketData(web3: Web3, network: NetworkNumber, ma
       _market.supplyIncentives.push({
         apy: _market.incentiveSupplyApy || '0',
         token: _market.symbol,
+        incentiveKind: 'staking',
       });
     }
 
@@ -302,6 +303,7 @@ export async function getAaveV3MarketData(web3: Web3, network: NetworkNumber, ma
       _market.borrowIncentives.push({
         apy: _market.incentiveBorrowApy,
         token: _market.incentiveBorrowToken!!,
+        incentiveKind: 'reward',
       });
     }
 
@@ -330,6 +332,7 @@ export async function getAaveV3MarketData(web3: Web3, network: NetworkNumber, ma
         _market.supplyIncentives.push({
           token: supplyRewardData.rewardTokenSymbol,
           apy: rewardApy,
+          incentiveKind: 'reward',
         });
       }
     });
@@ -356,6 +359,7 @@ export async function getAaveV3MarketData(web3: Web3, network: NetworkNumber, ma
         _market.borrowIncentives.push({
           token: borrowRewardData.rewardTokenSymbol,
           apy: rewardApy,
+          incentiveKind: 'reward',
         });
       }
     });

--- a/src/types/aave.ts
+++ b/src/types/aave.ts
@@ -87,6 +87,7 @@ export interface MorphoAaveV2AssetData extends AaveV2AssetData {
 export interface IncentiveData {
   token: string,
   apy: string,
+  incentiveKind?: 'staking' | 'reward';
 }
 
 export interface AaveV3AssetData extends AaveAssetData {


### PR DESCRIPTION
Da bismo ispravno izracunari nagrade za supply i borrow pojedinih tokena, moramo da razlikujemo apy koji dolazi od supply/borrow pozicija i apy koji dolazi kroz stakingTokene (tipa wstETH)